### PR TITLE
[IOT:vagrant] Feature/vm-provisioning-script-vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+p1/.vagrant
+p2/.vagrant
+p3/.vagrant
+
+p1/.shared/node-token.pub

--- a/p1/Makefile
+++ b/p1/Makefile
@@ -1,0 +1,20 @@
+ROOT_DIRECTORY := $(shell git rev-parse --show-toplevel)
+
+MASTER := gehovhanS
+WORKER := gehovhanSW
+
+# TODO: Be able to connect with SSH on both machines with no password.
+MASTER_VAGRANT_FILE_PATH := $(ROOT_DIRECTORY)/p1
+
+up:
+	cd $(MASTER_VAGRANT_FILE_PATH) && vagrant up
+
+re:
+	cd $(MASTER_VAGRANT_FILE_PATH) && vagrant reload
+
+clean:
+	cd $(MASTER_VAGRANT_FILE_PATH) && vagrant destroy -f $(MASTER) $(WORKER)
+
+test:
+	cd $(MASTER_VAGRANT_FILE_PATH) && vagrant halt
+

--- a/p1/Vagrantfile
+++ b/p1/Vagrantfile
@@ -1,0 +1,53 @@
+Vagrant.configure("2") do |config|
+
+  config.vm.define "gehovhanS" do |master|
+    master.vm.box = "bento/ubuntu-20.04"
+    master.vm.hostname = "gehovhanS"
+    master.vm.box_check_update = true
+    master.vm.network "private_network", ip: "192.168.56.110"
+    master.vm.synced_folder "./.shared", "/vagrant_shared"
+    master.vm.provider "vmware_desktop" do |vmware|
+      vmware.memory = 4096
+      vmware.cpus = 2
+    end
+    master.vm.provision "shell", path: "scripts/net-tools/install_net_tools.sh",
+      env: {
+            "MASTER_IP" => "192.168.56.110",
+            "WORKER_IP" => "192.168.56.111",
+            "TOKEN_FILE_PATH" => "/vagrant_shared/node-token.pub"
+      }
+    master.vm.provision "shell", path: "scripts/k3s/install_k3s_server.sh",
+      env: {
+            "MASTER_IP" => "192.168.56.110",
+            "WORKER_IP" => "192.168.56.111",
+            "TOKEN_FILE_PATH" => "/vagrant_shared/node-token.pub"
+      }
+  end
+
+  config.vm.define "gehovhanSW" do |worker|
+    worker.vm.box = "bento/ubuntu-20.04"
+    worker.vm.hostname = "gehovhanSW"
+    worker.vm.box_check_update = true
+    worker.vm.network "private_network", ip: "192.168.56.111"
+    worker.vm.synced_folder "./.shared", "/vagrant_shared"
+
+    worker.vm.provider "vmware_desktop" do |vmware|
+      vmware.memory = 2048
+      vmware.cpus = 2
+    end
+
+    worker.vm.provision "shell", path: "scripts/net-tools/install_net_tools.sh",
+      env: {
+            "MASTER_IP" => "192.168.56.110",
+            "WORKER_IP" => "192.168.56.111",
+            "TOKEN_FILE_PATH" => "/vagrant_shared/node-token.pub"
+      }
+    worker.vm.provision "shell", path: "scripts/k3s-agent/install_k3s_agent.sh",
+      env: {
+            "MASTER_IP" => "192.168.56.110",
+            "WORKER_IP" => "192.168.56.111",
+            "TOKEN_FILE_PATH" => "/vagrant_shared/node-token.pub"
+      }
+  end
+
+end

--- a/p1/scripts/__tools__/status_test.sh
+++ b/p1/scripts/__tools__/status_test.sh
@@ -1,0 +1,2 @@
+sudo systemctl status k3s
+sudo systemctl status k3s-agent

--- a/p1/scripts/k3s-agent/install_k3s_agent.sh
+++ b/p1/scripts/k3s-agent/install_k3s_agent.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo -e "\e[36m==>\e[0m $(hostname): Installing K3s agent and connecting to master at gehovhanS.42.fr..."
+export INSTALL_K3S_EXEC="agent --server https://gehovhanS.42.fr:6443 --token-file ${TOKEN_FILE_PATH} --node-ip=${WORKER_IP}"
+curl -sfL https://get.k3s.io | sh -
+
+echo -e "\e[36m==>\e[0m $(hostname): K3s agent successfully joined the cluster."

--- a/p1/scripts/k3s/install_k3s_server.sh
+++ b/p1/scripts/k3s/install_k3s_server.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo -e "\e[36m==>\e[0m $(hostname): Installing K3s Control Plane..."
+
+export INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644 --advertise-address=${MASTER_IP} --node-ip=${MASTER_IP}"
+curl -sfL https://get.k3s.io | sh -
+
+echo -e "\e[36m==>\e[0m $(hostname): Saving K3s node token for worker nodes..."
+sudo cat /var/lib/rancher/k3s/server/node-token > "$TOKEN_FILE_PATH"
+
+echo -e "\e[36m==>\e[0m $(hostname): K3s Control Plane setup complete."

--- a/p1/scripts/net-tools/install_net_tools.sh
+++ b/p1/scripts/net-tools/install_net_tools.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo -e "\e[36m==>\e[0m $(hostname): Installing net-tools..."
+sudo apt-get update && sudo apt-get install -y curl net-tools
+
+echo -e "\e[36m==>\e[0m $(hostname): Add host-only domain for master node."
+echo "${MASTER_IP} gehovhanS gehovhanS.42.fr" >> /etc/hosts
+
+echo -e "\e[36m==>\e[0m $(hostname): Add host-only domain for worker node."
+echo "${WORKER_IP} gehovhanSW gehovhanSW.42.fr" >> /etc/hosts
+
+echo -e "\e[36m==>\e[0m $(hostname): net-tools installed successfully..."


### PR DESCRIPTION
[IOT:vagrant] Add Vagrantfile for multi-node K3s cluster setup

- Defines two VMs: master (gehovhanS) and worker (gehovhanSW) with private IPs
- Configures synced shared folder for sharing K3s node token between nodes
- Sets up provisioning scripts for installing net-tools and K3s components
- Allocates resources for each VM using vmware_desktop provider
- Passes environment variables for IPs and token path to provisioning scripts